### PR TITLE
Add compatibility option for DING

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,14 +9,12 @@ const workspaceManager = global.workspace_manager;
 
 let WorkspaceIndicator = GObject.registerClass(
   class WorkspaceIndicator extends St.Button {
-    _init(workspace, active, settings) {
+    _init(workspace, active, skip_taskbar_mode, primary_workspace_mode) {
       super._init();
       this.active = active;
       this.workspace = workspace;
-      this.skip_taskbar_mode = settings.get_boolean("skip-taskbar-mode");
-      this.primary_workspace_mode = settings.get_boolean(
-        "primary-workspace-mode"
-      );
+      this.skip_taskbar_mode = skip_taskbar_mode;
+      this.primary_workspace_mode = primary_workspace_mode;
 
       // setup widgets
       this._widget = new St.Widget({
@@ -119,14 +117,14 @@ class WorkspaceLayout {
       }
     );
 
-    this._panelPositionChangedId = this.settings.connect(
+    this._skipTaskbarModeChangedId = this.settings.connect(
       "changed::skip-taskbar-mode",
       () => {
         this.add_panel_button();
       }
     );
 
-    this._panelPositionChangedId = this.settings.connect(
+    this._primaryWorkspaceModeChangedId = this.settings.connect(
       "changed::primary-workspace-mode",
       () => {
         this.add_panel_button();
@@ -143,6 +141,8 @@ class WorkspaceLayout {
     workspaceManager.disconnect(this._workspaceAddedId);
     workspaceManager.disconnect(this._workspaceRemovedId);
     this.settings.disconnect(this._panelPositionChangedId);
+    this.settings.disconnect(this._skipTaskbarModeChangedId);
+    this.settings.disconnect(this._primaryWorkspaceModeChangedId);
   }
 
   add_panel_button() {
@@ -188,7 +188,8 @@ class WorkspaceLayout {
         let indicator = new WorkspaceIndicator(
           workspace,
           i == active_index,
-          this.settings
+          this.settings.get_boolean("skip-taskbar-mode"),
+          this.settings.get_boolean("primary-workspace-mode")
         );
 
         this.box_layout.add_actor(indicator);

--- a/extension.js
+++ b/extension.js
@@ -9,12 +9,11 @@ const workspaceManager = global.workspace_manager;
 
 let WorkspaceIndicator = GObject.registerClass(
   class WorkspaceIndicator extends St.Button {
-    _init(workspace, active, skip_taskbar_mode, primary_workspace_mode) {
+    _init(workspace, active, skip_taskbar_mode) {
       super._init();
       this.active = active;
       this.workspace = workspace;
       this.skip_taskbar_mode = skip_taskbar_mode;
-      this.primary_workspace_mode = primary_workspace_mode;
 
       // setup widgets
       this._widget = new St.Widget({
@@ -69,16 +68,12 @@ let WorkspaceIndicator = GObject.registerClass(
     has_user_window() {
       let windows = this.workspace.list_windows();
 
-      if (!this.skip_taskbar_mode && !this.primary_workspace_mode) {
+      if (!this.skip_taskbar_mode) {
         return windows.length > 0;
       }
 
       return windows.some((w) => {
-        let is_shown = !this.skip_taskbar_mode || !w.is_skip_taskbar();
-        let is_primary =
-          !this.primary_workspace_mode || w.is_on_primary_monitor();
-
-        return is_shown && is_primary;
+        return !w.is_skip_taskbar();
       });
     }
 
@@ -124,13 +119,6 @@ class WorkspaceLayout {
       }
     );
 
-    this._primaryWorkspaceModeChangedId = this.settings.connect(
-      "changed::primary-workspace-mode",
-      () => {
-        this.add_panel_button();
-      }
-    );
-
     this.add_panel_button();
   }
 
@@ -142,7 +130,6 @@ class WorkspaceLayout {
     workspaceManager.disconnect(this._workspaceRemovedId);
     this.settings.disconnect(this._panelPositionChangedId);
     this.settings.disconnect(this._skipTaskbarModeChangedId);
-    this.settings.disconnect(this._primaryWorkspaceModeChangedId);
   }
 
   add_panel_button() {
@@ -188,8 +175,7 @@ class WorkspaceLayout {
         let indicator = new WorkspaceIndicator(
           workspace,
           i == active_index,
-          this.settings.get_boolean("skip-taskbar-mode"),
-          this.settings.get_boolean("primary-workspace-mode")
+          this.settings.get_boolean("skip-taskbar-mode")
         );
 
         this.box_layout.add_actor(indicator);

--- a/prefs.js
+++ b/prefs.js
@@ -53,6 +53,8 @@ function buildPrefsWidget() {
 
   prefsWidget.attach(title, 0, 0, 2, 1);
 
+  // Panel Position Chooser
+
   let panel_position_label = new Gtk.Label({
     label: "Panel Position",
     halign: Gtk.Align.START,
@@ -71,6 +73,56 @@ function buildPrefsWidget() {
     "panel-position",
     panel_position_combo,
     "active_id",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
+  // Skip Taskbar Mode Selector
+
+  let skip_taskbar_mode_label = new Gtk.Label({
+    label:
+      "Ignore Taskbar-Skipped Windows\r" +
+      "<small>These include hidden windows from the desktop-icons-ng extension.</small>",
+    halign: Gtk.Align.START,
+    use_markup: true,
+  });
+
+  let skip_taskbar_mode_toggle = new Gtk.Switch({
+    active: this.settings.get_boolean("skip-taskbar-mode"),
+    halign: Gtk.Align.END,
+    visible: true,
+  });
+
+  prefsWidget.attach(skip_taskbar_mode_label, 0, 2, 2, 1);
+  prefsWidget.attach(skip_taskbar_mode_toggle, 2, 2, 2, 1);
+
+  this.settings.bind(
+    "skip-taskbar-mode",
+    skip_taskbar_mode_toggle,
+    "active",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
+  // Primary Workspace Mode Selector
+
+  let primary_workspace_mode_label = new Gtk.Label({
+    label: "Only Count Primary Monitor Windows",
+    halign: Gtk.Align.START,
+    use_markup: true,
+  });
+
+  let primary_workspace_mode_toggle = new Gtk.Switch({
+    active: this.settings.get_boolean("primary-workspace-mode"),
+    halign: Gtk.Align.END,
+    visible: true,
+  });
+
+  prefsWidget.attach(primary_workspace_mode_label, 0, 3, 2, 1);
+  prefsWidget.attach(primary_workspace_mode_toggle, 2, 3, 2, 1);
+
+  this.settings.bind(
+    "primary-workspace-mode",
+    primary_workspace_mode_toggle,
+    "active",
     Gio.SettingsBindFlags.DEFAULT
   );
 

--- a/prefs.js
+++ b/prefs.js
@@ -102,30 +102,6 @@ function buildPrefsWidget() {
     Gio.SettingsBindFlags.DEFAULT
   );
 
-  // Primary Workspace Mode Selector
-
-  let primary_workspace_mode_label = new Gtk.Label({
-    label: "Only Count Primary Monitor Windows",
-    halign: Gtk.Align.START,
-    use_markup: true,
-  });
-
-  let primary_workspace_mode_toggle = new Gtk.Switch({
-    active: this.settings.get_boolean("primary-workspace-mode"),
-    halign: Gtk.Align.END,
-    visible: true,
-  });
-
-  prefsWidget.attach(primary_workspace_mode_label, 0, 3, 2, 1);
-  prefsWidget.attach(primary_workspace_mode_toggle, 2, 3, 2, 1);
-
-  this.settings.bind(
-    "primary-workspace-mode",
-    primary_workspace_mode_toggle,
-    "active",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
   // only gtk3 apps need to run show_all()
   if (ShellVersion < 40) {
     prefsWidget.show_all();

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -10,7 +10,7 @@
       <summary>Choose the position of the workspace indicator.</summary>
     </key>
     <key name="skip-taskbar-mode" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Ignore Taskbar-Skipped Windows.</summary>
       <description>
         Set to true to ignore `is_skip_taskbar` windows when determining in-use workspaces. This includes hidden windows created by the desktop-icons-ng extension.

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -9,5 +9,19 @@
       <default>'right'</default>
       <summary>Choose the position of the workspace indicator.</summary>
     </key>
+    <key name="skip-taskbar-mode" type="b">
+      <default>false</default>
+      <summary>Ignore Taskbar-Skipped Windows.</summary>
+      <description>
+        Set to true to ignore `is_skip_taskbar` windows when determining in-use workspaces. This includes hidden windows created by the desktop-icons-ng extension.
+      </description>
+    </key>
+    <key name="primary-workspace-mode" type="b">
+      <default>false</default>
+      <summary>Only Count Primary Monitor Windows.</summary>
+      <description>
+        Set to true to only count primary monitor windows when determining in-use workspaces.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -16,12 +16,5 @@
         Set to true to ignore `is_skip_taskbar` windows when determining in-use workspaces. This includes hidden windows created by the desktop-icons-ng extension.
       </description>
     </key>
-    <key name="primary-workspace-mode" type="b">
-      <default>false</default>
-      <summary>Only Count Primary Monitor Windows.</summary>
-      <description>
-        Set to true to only count primary monitor windows when determining in-use workspaces.
-      </description>
-    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Hi Michael, thanks for this extension, it's really nice.

## Fixes
This should fix issue https://github.com/MichaelAquilina/improved-workspace-indicator/issues/3 re: in-use workspaces with DING. DING creates a window on each monitor with [is_skip_taskbar](https://gjs-docs.gnome.org/meta8~8_api/meta.window#method-is_skip_taskbar) set to true. I am hopeful that this is a general fix for other apps/extensions, but if not, non-standard windows are also identifiable through their `window_type`.

~~It also adds the option to ignore windows outside the non-primary monitor, which is useful if you have `org.gnome.mutter workspaces-only-on-primary` set to true.~~

## Notes
- Originally tried detecting if DING is installed rather than adding an option, but on second thought maybe an option is better if it fixes this issue for other apps/extensions too
- Not really sure how to do the subtext properly such that the toggle button sizes are equal height:
    <img src="https://user-images.githubusercontent.com/12143900/130416814-6957907b-b5eb-483a-98f3-9f071b8b42ae.png" width="300">
    EDIT: picture outdated, bottom option moved to a separate PR
