### PR TITLE
Add compatibility option for workspaces only on primary

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -102,6 +102,30 @@ function buildPrefsWidget() {
     Gio.SettingsBindFlags.DEFAULT
   );
 
+  // Primary Workspace Mode Selector
+
+  let primary_workspace_mode_label = new Gtk.Label({
+    label: "Only Count Primary Monitor Windows",
+    halign: Gtk.Align.START,
+    use_markup: true,
+  });
+
+  let primary_workspace_mode_toggle = new Gtk.Switch({
+    active: this.settings.get_boolean("primary-workspace-mode"),
+    halign: Gtk.Align.END,
+    visible: true,
+  });
+
+  prefsWidget.attach(primary_workspace_mode_label, 0, 3, 2, 1);
+  prefsWidget.attach(primary_workspace_mode_toggle, 2, 3, 2, 1);
+
+  this.settings.bind(
+    "primary-workspace-mode",
+    primary_workspace_mode_toggle,
+    "active",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
   // only gtk3 apps need to run show_all()
   if (ShellVersion < 40) {
     prefsWidget.show_all();

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -16,5 +16,12 @@
         Set to true to ignore `is_skip_taskbar` windows when determining in-use workspaces. This includes hidden windows created by the desktop-icons-ng extension.
       </description>
     </key>
+    <key name="primary-workspace-mode" type="b">
+      <default>false</default>
+      <summary>Only Count Primary Monitor Windows.</summary>
+      <description>
+        Set to true to only count primary monitor windows when determining in-use workspaces.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Creating this draft PR for visibility if anyone else is wondering about this, or wants to use it in the meantime even with the bug. Not for merging until we work out a fix for dragging windows from secondary to primary marking all workspaces in-use. Additional context: https://github.com/MichaelAquilina/improved-workspace-indicator/pull/6#issuecomment-904324164

Rather than a dirty fix it might be better to clarify if the `window-removed` and `list_windows()` behaviours in Mutter are intended or not. ~~I may leisurely dig into Mutter over the next few weeks to see if this is worth an issue.~~