### PR TITLE
Update .active css class name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -29,7 +29,7 @@ let WorkspaceIndicator = GObject.registerClass(
       });
 
       if (this.active) {
-        this._statusLabel.add_style_class_name("active");
+        this._statusLabel.add_style_class_name("workspace-indicator-active");
       }
 
       this._widget.add_actor(this._statusLabel);

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -25,6 +25,6 @@
   border-left-width: 1px;
 }
 
-.active {
+.workspace-indicator-active {
   background-color: rgba(20, 200, 200, 0.5);
 }


### PR DESCRIPTION
Updated the css class name for the active desktop indicator.

The default name ".active" caused compatibility issues with other gnome extensions (namely asus-ctl) whereby the colour to show  the active desktop, would also become the highlight colour (when mousing over the icon and menu) for the other extension.