### PR TITLE
Custom CSS stylesheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Improved Workspace Indicator
 
-Gnome shell extension that provides a workspace indicator more similar to i3/sway
+GNOME Shell extension that provides a workspace indicator more similar to i3/sway.
 
 Namely:
 
@@ -13,6 +13,56 @@ Namely:
 
 Run `make install`
 
+## How to use custom CSS stylesheet
+
+You can use a custom CSS stylesheet to change a look of workspace indicator widget.
+
+#### 1. Write your own CSS stylesheet
+
+As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for IWI.
+
+> **Note**
+> Creating custom CSS stylesheets might require from you some actual knowledge of CSS. You can check [this](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) tutorial on MDN to learn basics of CSS.
+
+<details open>
+<summary>Which parts of a stylesheet you would want to modify:</summary>
+
+#### Workspace indicator
+```css
+.panel-workspace-indicator,
+.panel-workspace-indicator-box .workspace {
+  border: 1px solid #cccccc;
+  background-color: rgba(200, 200, 200, 0.5);
+}
+```
+###### Located in lines [13-17](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L13-L17)
+
+In this part you can customize a look of a single workspace indicator, as well as colors for an inactive workspace.
+
+#### Active workspace
+```css
+.workspace-indicator-active {
+  background-color: rgba(20, 200, 200, 0.5);
+}
+```
+###### Located in lines [28-30](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L28-L30)
+
+Here you can change properties of an active workspace indicator.
+
+</details>
+
+#### 2. Choose your custom stylesheet in extension's preferences
+
+Open IWI's preferences and locate `Custom CSS stylesheet` row. Now either click on folder button which will open a file chooser dialog, or paste a path of your stylesheet file into textbox.
+
+#### 3. Reload an extension
+
+Close IWI's preferences window and re-enable extension by toggling an switch in extensions manager.
+
+> **Note**
+> You can disable custom CSS by removing an path from textbox in preferences window.
+
+
 ## Publishing a new version
 
 1. Compile the schema
@@ -21,10 +71,10 @@ Run `make install`
 glib-compile-schemas schemas
 ```
 
-2. zip up the contents
+2. Zip up the contents
 
 ```shell
 rm *.zip && zip -r improved-workspace-indicator@michaelaquilina.github.io.zip . --exclude=README.md --exclude=.gitignore --exclude=screenshot.png --exclude=.git/\* --exclude=.circleci/\* --exclude=Makefile
 ```
 
-3. upload a new version to https://extensions.gnome.org/upload/
+3. Upload a new version to https://extensions.gnome.org/upload/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can use a custom CSS stylesheet to change a look of workspace indicator widg
 
 #### 1. Write your own CSS stylesheet
 
-As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for IWI.
+As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for Improved Workspace Indicator.
 
 > **Note**
 > Creating custom CSS stylesheets might require from you some actual knowledge of CSS. You can check [this](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) tutorial on MDN to learn basics of CSS.
@@ -55,11 +55,11 @@ Here you can change properties of an active workspace indicator.
 
 #### 2. Choose your custom stylesheet in extension's preferences
 
-Open IWI's preferences and locate `Custom CSS stylesheet` row. Now either click on folder button which will open a file chooser dialog, or paste a path of your stylesheet file into textbox.
+Open extension's preferences and locate `Custom CSS stylesheet` row. Now either click on folder button which will open a file chooser dialog, or paste a path of your stylesheet file into textbox.
 
 #### 3. Reload an extension
 
-Close IWI's preferences window and re-enable extension by toggling an switch in extensions manager.
+Close preferences window and re-enable extension by toggling an switch in extensions manager.
 
 > **Note**
 > You can disable custom CSS by removing an path from textbox in preferences window.

--- a/README.md
+++ b/README.md
@@ -15,55 +15,9 @@ Namely:
 
 Run `make install`
 
-## How to use custom CSS stylesheet
+## How to customize the look
 
-You can use a custom CSS stylesheet to change a look of workspace indicator widget.
-
-#### 1. Write your own CSS stylesheet
-
-As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for Improved Workspace Indicator.
-
-> **Note**
-> Creating custom CSS stylesheets might require from you some actual knowledge of CSS. You can check [this](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) tutorial on MDN to learn basics of CSS.
-
-<details open>
-<summary>Which parts of a stylesheet you would want to modify:</summary>
-
-#### Workspace indicator
-```css
-.panel-workspace-indicator,
-.panel-workspace-indicator-box .workspace {
-  border: 1px solid #cccccc;
-  background-color: rgba(200, 200, 200, 0.5);
-}
-```
-###### Located in lines [13-17](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L13-L17)
-
-In this part you can customize a look of a single workspace indicator, as well as colors for an inactive workspace.
-
-#### Active workspace
-```css
-.workspace-indicator-active {
-  background-color: rgba(20, 200, 200, 0.5);
-}
-```
-###### Located in lines [28-30](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L28-L30)
-
-Here you can change properties of an active workspace indicator.
-
-</details>
-
-#### 2. Choose your custom stylesheet in extension's preferences
-
-Open extension's preferences and locate `Custom CSS stylesheet` row. Now either click on folder button which will open a file chooser dialog, or paste a path of your stylesheet file into textbox.
-
-#### 3. Reload an extension
-
-Close preferences window and re-enable extension by toggling an switch in extensions manager.
-
-> **Note**
-> You can disable custom CSS by removing an path from textbox in preferences window.
-
+*Refer to the [Custom CSS Guide](docs/how_to_custom_css.md) if you want to customize the look of Improved Workspace Indicator.*
 
 ## Publishing a new version
 

--- a/docs/how_to_custom_css.md
+++ b/docs/how_to_custom_css.md
@@ -1,0 +1,48 @@
+## How to use custom CSS stylesheet
+
+You can use custom CSS stylesheets to change a look of workspace indicator widget.
+
+#### 1. Write your own CSS stylesheet
+
+As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for Improved Workspace Indicator.
+
+> **Note**
+> Creating custom CSS stylesheets might require from you some actual knowledge of CSS. You can check [this](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) tutorial on MDN to learn basics of CSS.
+
+<details open>
+<summary>Which parts of a stylesheet you would want to modify:</summary>
+
+#### Workspace indicator
+```css
+.panel-workspace-indicator,
+.panel-workspace-indicator-box .workspace {
+  border: 1px solid #cccccc;
+  background-color: rgba(200, 200, 200, 0.5);
+}
+```
+###### Located in lines [13-17](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L13-L17)
+
+In this part you can customize a look of a single workspace indicator, as well as colors for an inactive workspace.
+
+#### Active workspace
+```css
+.workspace-indicator-active {
+  background-color: rgba(20, 200, 200, 0.5);
+}
+```
+###### Located in lines [28-30](https://github.com/MichaelAquilina/improved-workspace-indicator/blob/b03afe9d3fe562c418ff25967e61eded67bf17c6/stylesheet.css#L28-L30)
+
+Here you can change properties of an active workspace indicator.
+
+</details>
+
+#### 2. Choose your custom stylesheet in extension's preferences
+
+Open extension's preferences and locate `Custom CSS stylesheet` row. Now either click on folder button which will open a file chooser dialog, or paste a path of your stylesheet file into textbox.
+
+#### 3. Reload an extension
+
+Close preferences window and re-enable extension by toggling an switch in extensions manager.
+
+> **Note**
+> You can disable custom CSS by removing an path from textbox in preferences window.

--- a/docs/how_to_custom_css.md
+++ b/docs/how_to_custom_css.md
@@ -4,7 +4,7 @@ You can use custom CSS stylesheets to change a look of workspace indicator widge
 
 #### 1. Write your own CSS stylesheet
 
-As a base, use [stylesheet.css](./stylesheet.css), as it has all classes needed to create a custom stylesheet for Improved Workspace Indicator.
+As a base, use [stylesheet.css](../stylesheet.css), as it has all classes needed to create a custom stylesheet for Improved Workspace Indicator.
 
 > **Note**
 > Creating custom CSS stylesheets might require from you some actual knowledge of CSS. You can check [this](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) tutorial on MDN to learn basics of CSS.

--- a/extension.js
+++ b/extension.js
@@ -225,5 +225,14 @@ class WorkspaceLayout {
 }
 
 function init() {
+  let settings = ExtensionUtils.getSettings();
+
+  if (settings.get_string("custom-css-path") !== "") {
+    let themeContext = St.ThemeContext.get_for_stage(global.stage);
+    let themesLoaded = themeContext.get_theme().get_custom_stylesheets();
+      
+    themeContext.get_theme().unload_stylesheet(themesLoaded[0]);
+  }
+
   return new WorkspaceLayout();
 }

--- a/extension.js
+++ b/extension.js
@@ -95,13 +95,25 @@ class WorkspaceLayout {
     this.indicators = [];
     this.panel_button = null;
     this.box_layout = null;
+    this.themeContext = St.ThemeContext.get_for_stage(global.stage);
+    this.settings = ExtensionUtils.getSettings();
+
+    // Load custom CSS
+    this.css_file = null;
+
+    if (this.settings.get_string("custom-css-path") !== "") {
+      this.css_file = Gio.File.new_for_path(this.settings.get_string("custom-css-path"));
+      this.themeContext.get_theme().load_stylesheet(this.css_file);
+
+      this.themesLoaded = this.themeContext.get_theme().get_custom_stylesheets();
+      this.themeContext.get_theme().unload_stylesheet(this.themesLoaded[0]);
+    }
 
     let gschema = Gio.SettingsSchemaSource.new_from_directory(
       Me.dir.get_child("schemas").get_path(),
       Gio.SettingsSchemaSource.get_default(),
       false
     );
-    this.settings = ExtensionUtils.getSettings();
 
     this._panelPositionChangedId = this.settings.connect(
       "changed::panel-position",
@@ -135,6 +147,9 @@ class WorkspaceLayout {
     this.settings.disconnect(this._panelPositionChangedId);
     this.settings.disconnect(this._skipTaskbarModeChangedId);
     this.settings.disconnect(this._changeOnClickChangedId);
+    if (this.css_file !== null) {
+      this.themeContext.get_theme().unload_stylesheet(this.css_file);
+    }
   }
 
   add_panel_button() {

--- a/extension.js
+++ b/extension.js
@@ -102,11 +102,13 @@ class WorkspaceLayout {
     this.css_file = null;
 
     if (this.settings.get_string("custom-css-path") !== "") {
+      this.themesLoaded = this.themeContext.get_theme().get_custom_stylesheets();
+      for (let i = 0; i < this.themesLoaded.length; i++) {
+        this.themeContext.get_theme().unload_stylesheet(this.themesLoaded[i]);
+      }
+
       this.css_file = Gio.File.new_for_path(this.settings.get_string("custom-css-path"));
       this.themeContext.get_theme().load_stylesheet(this.css_file);
-
-      this.themesLoaded = this.themeContext.get_theme().get_custom_stylesheets();
-      this.themeContext.get_theme().unload_stylesheet(this.themesLoaded[0]);
     }
 
     let gschema = Gio.SettingsSchemaSource.new_from_directory(
@@ -225,14 +227,5 @@ class WorkspaceLayout {
 }
 
 function init() {
-  let settings = ExtensionUtils.getSettings();
-
-  if (settings.get_string("custom-css-path") !== "") {
-    let themeContext = St.ThemeContext.get_for_stage(global.stage);
-    let themesLoaded = themeContext.get_theme().get_custom_stylesheets();
-      
-    themeContext.get_theme().unload_stylesheet(themesLoaded[0]);
-  }
-
   return new WorkspaceLayout();
 }

--- a/prefs.js
+++ b/prefs.js
@@ -168,12 +168,14 @@ function buildPrefsWidget() {
       orientation: Gtk.Orientation.HORIZONTAL,
       css_classes: Array("linked"), // Style class in libadwaita
       halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
     });
   } else {
     var custom_css_box = new Gtk.Box({
       orientation: Gtk.Orientation.HORIZONTAL,
       spacing: 5,
       halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
     });
   }
 
@@ -183,6 +185,36 @@ function buildPrefsWidget() {
       "<small>You need to reload this extension to see the changes.</small>",
     halign: Gtk.Align.START,
     use_markup: true,
+  });
+
+  if (ShellVersion < 40) {
+    let custom_css_help_image = new Gtk.Image({
+      icon_name: "dialog-information-symbolic",
+    });
+
+    var custom_css_help = new Gtk.Button({
+      image: custom_css_help_image,
+      tooltip_text: "Click for more information",
+      halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
+    });
+  } else {
+    var custom_css_help = new Gtk.Button({
+      icon_name: "dialog-information-symbolic",
+      tooltip_text: "Click for more information",
+      halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
+    });
+  }
+
+  custom_css_help.connect('clicked', () => {
+    Gio.Subprocess.new(
+      Array(
+        "xdg-open",
+        "https://github.com/MichaelAquilina/improved-workspace-indicator#how-to-use-custom-css-stylesheet"
+      ),
+      Gio.SubprocessFlags.NONE,
+    );
   });
 
   let custom_css_entry = new Gtk.Entry({
@@ -261,6 +293,7 @@ function buildPrefsWidget() {
   }
 
   prefsWidget.attach(custom_css_label, 0, 6, 2, 1);
+  prefsWidget.attach(custom_css_help, 1, 6, 1, 1);
   prefsWidget.attach(custom_css_box, 2, 6, 2, 1);
 
 

--- a/prefs.js
+++ b/prefs.js
@@ -139,6 +139,30 @@ function buildPrefsWidget() {
     custom_css_set_path.length,
   );
 
+  function filechooser_open() {
+    let dialog = new Gtk.FileChooserNative({
+      title: "Choose a valid CSS stylesheet file",
+      transient_for: null, // TODO: Change to global Gtk.Window object
+      action: Gtk.FileChooserAction.OPEN,
+    });
+    dialog.set_modal(true);
+
+    let css_filter = new Gtk.FileFilter();
+    css_filter.set_name("CSS stylesheet (*.css)");
+    css_filter.add_mime_type("text/css");
+    dialog.add_filter(css_filter);
+
+    dialog.connect('response', (self, response) => {
+      if (response === Gtk.ResponseType.ACCEPT) {
+        let gfile = dialog.get_file();
+        let file_path = gfile.get_path();
+        entry_buffer.set_text(file_path, file_path.length);
+      }
+      dialog.destroy();
+    });
+    dialog.show();
+  }
+
   if (ShellVersion < 40) {
     let custom_css_button_image = new Gtk.Image({
       icon_name: "folder-symbolic",
@@ -152,6 +176,10 @@ function buildPrefsWidget() {
       icon_name: "folder-symbolic",
     });
   }
+
+  custom_css_button.connect('clicked', () => {
+    filechooser_open();
+  });
 
   prefsWidget.connect('unrealize', () => {
     let custom_css_dest = entry_buffer.get_text();

--- a/prefs.js
+++ b/prefs.js
@@ -125,13 +125,16 @@ function buildPrefsWidget() {
 
   let custom_css_label = new Gtk.Label({
     label: 
-      "Custom CSS stylesheet\r" + 
-      "<small>You need to reload the extension to see the changes.</small>",
+      "Custom CSS stylesheet\r" +
+      "<small>You need to reload this extension to see the changes.</small>",
     halign: Gtk.Align.START,
     use_markup: true,
   });
 
-  let custom_css_entry = new Gtk.Entry();
+  let custom_css_entry = new Gtk.Entry({
+    tooltip_text: "Remove path from entry box to restore a original style.",
+  });
+
   let entry_buffer = custom_css_entry.get_buffer();
 
   let custom_css_set_path = this.settings.get_string("custom-css-path");

--- a/prefs.js
+++ b/prefs.js
@@ -118,16 +118,16 @@ function buildPrefsWidget() {
 
   // Custom CSS stylesheet
 
-  if (ShellVersion < 42) {
+  if (ShellVersion >= 42) {
     var custom_css_box = new Gtk.Box({
       orientation: Gtk.Orientation.HORIZONTAL,
-      spacing: 5,
+      css_classes: Array("linked"), // Style class in libadwaita
       halign: Gtk.Align.END,
     });
   } else {
     var custom_css_box = new Gtk.Box({
       orientation: Gtk.Orientation.HORIZONTAL,
-      css_classes: Array("linked"), // Style class in libadwaita
+      spacing: 5,
       halign: Gtk.Align.END,
     });
   }

--- a/prefs.js
+++ b/prefs.js
@@ -117,6 +117,7 @@ function buildPrefsWidget() {
   );
 
   // Custom CSS stylesheet
+
   let custom_css_box = new Gtk.Box({
     orientation: Gtk.Orientation.HORIZONTAL,
     css_classes: Array("linked"),
@@ -146,10 +147,10 @@ function buildPrefsWidget() {
   function filechooser_open() {
     let dialog = new Gtk.FileChooserNative({
       title: "Choose a valid CSS stylesheet file",
-      transient_for: null, // TODO: Change to global Gtk.Window object
+      transient_for: null, // TODO: Change it to preferences Adw.PreferencesWindow object
+      modal: true,
       action: Gtk.FileChooserAction.OPEN,
     });
-    dialog.set_modal(true);
 
     let css_filter = new Gtk.FileFilter();
     css_filter.set_name("CSS stylesheet (*.css)");
@@ -164,6 +165,7 @@ function buildPrefsWidget() {
       }
       dialog.destroy();
     });
+    dialog.ref(); // File chooser closes itself in nobody is holding its ref
     dialog.show();
   }
 

--- a/prefs.js
+++ b/prefs.js
@@ -78,6 +78,7 @@ function buildPrefsWidget() {
 
   let skip_taskbar_mode_toggle = new Gtk.Switch({
     active: this.settings.get_boolean("skip-taskbar-mode"),
+    valign: Gtk.Align.CENTER,
     halign: Gtk.Align.END,
     visible: true,
   });

--- a/prefs.js
+++ b/prefs.js
@@ -118,11 +118,19 @@ function buildPrefsWidget() {
 
   // Custom CSS stylesheet
 
-  let custom_css_box = new Gtk.Box({
-    orientation: Gtk.Orientation.HORIZONTAL,
-    css_classes: Array("linked"),
-    halign: Gtk.Align.END,
-  });
+  if (ShellVersion < 42) {
+    var custom_css_box = new Gtk.Box({
+      orientation: Gtk.Orientation.HORIZONTAL,
+      spacing: 5,
+      halign: Gtk.Align.END,
+    });
+  } else {
+    var custom_css_box = new Gtk.Box({
+      orientation: Gtk.Orientation.HORIZONTAL,
+      css_classes: Array("linked"), // Style class in libadwaita
+      halign: Gtk.Align.END,
+    });
+  }
 
   let custom_css_label = new Gtk.Label({
     label: 
@@ -147,7 +155,7 @@ function buildPrefsWidget() {
   function filechooser_open() {
     let dialog = new Gtk.FileChooserNative({
       title: "Choose a valid CSS stylesheet file",
-      transient_for: null, // TODO: Change it to preferences Adw.PreferencesWindow object
+      transient_for: null, // TODO: Change it to Adw.PreferencesWindow/Gtk.Window object
       modal: true,
       action: Gtk.FileChooserAction.OPEN,
     });
@@ -165,7 +173,7 @@ function buildPrefsWidget() {
       }
       dialog.destroy();
     });
-    dialog.ref(); // File chooser closes itself in nobody is holding its ref
+    dialog.ref(); // File chooser closes itself if nobody is holding its ref
     dialog.show();
   }
 

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -24,5 +24,12 @@
         Set to true to change to the workspace number on indicator click. Set to false to disable any action on click.
       </description>
     </key>
+    <key name="custom-css-path" type="s">
+      <default>""</default>
+      <summary>Custom path to CSS stylesheet</summary>
+      <description>
+        Type here a custom path to your CSS stylesheet (must be full path eg. /home/user/...), or leave it empty to restore original style.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -26,21 +26,21 @@
     </key>
     <key name="custom-css-path" type="s">
       <default>""</default>
-      <summary>Custom path to CSS stylesheet</summary>
+      <summary>Path to custom CSS stylesheet.</summary>
       <description>
-        Type here a custom path to your CSS stylesheet (must be full path eg. /home/user/...), or leave it empty to restore original style.
+        Enter a path to your custom CSS stylehseet (must be full path eg. /home/user/...), or leave it empty to restore original style.
       </description>
     </key>
     <key name="change-on-scroll" type="b">
       <default>true</default>
-      <summary>Change Workspaces on indicator mouse-scroll.</summary>
+      <summary>Change workspaces on indicator mouse-scroll.</summary>
       <description>
         Set to true to change to the workspace number by mouse-scroll over indicator.
       </description>
     </key>
     <key name="wrap-scroll" type="b">
       <default>true</default>
-      <summary>workspace wraparound with mouse-scroll</summary>
+      <summary>Workspace wraparound with mouse-scroll.</summary>
       <description>
         Set to true to loop back at first/last workspace when mouse-scroll.
       </description>


### PR DESCRIPTION
These commits add a basic loading mechanism for custom CSS stylesheets, and an configurable option in preferences window.
Fixes #4 and #13
I've also added a small fix for a stretched `skip_taskbar_mode_toggle` in preferences.

I'm setting this PR as a draft for now, because of a 2 main bugs in current implementation:
- ~~The `GtkFileChooserNative` currently isn't transient to the preferences window, and it closes itself randomly,~~ (Fixed in commit 240a6ec4059003c13c4db1d6a0d6af96eed8b422)
- ~~There is a lock/unlock bug, I need to investigate on that more, but it looks the same as a log-out/log-in bug that I've fixed it the latest commit (before bugfix, it loaded both default and custom stylesheets during initialization).~~ (Now it works as it should)

With the first one, I would need some help from someone who knows GJS better than me, and for a second bug I think I have a fix already, but I need to test it further.

~~There also could be a problem with that code I've added in init() function, because ego guidelines says "Your extension MUST NOT create any objects, connect any signals, add any main loop sources or modify GNOME Shell here." [(link)](https://gjs.guide/extensions/review-guidelines/review-guidelines.html#only-use-init-for-initialization), and I'm doing probably two things from that rule currently.~~ (Fix from a commit e5ebe2ca2474604a08f884616bf6ef3446bdcce3 removes any necessity for unloading stylesheets in init(), so extension review process shouldn't be a problem now)