### PR TITLE
Fix: react to reorder workspace signal

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -132,6 +132,7 @@ class WorkspaceLayout {
     workspaceManager.disconnect(this._workspaceSwitchedId);
     workspaceManager.disconnect(this._workspaceAddedId);
     workspaceManager.disconnect(this._workspaceRemovedId);
+    workspaceManager.disconnect(this._workspaceReordered);
     this.settings.disconnect(this._panelPositionChangedId);
     this.settings.disconnect(this._skipTaskbarModeChangedId);
     this.settings.disconnect(this._changeOnClickChangedId);
@@ -163,6 +164,10 @@ class WorkspaceLayout {
     );
     this._workspaceRemovedId = workspaceManager.connect_after(
       "workspace-removed",
+      this.add_indicators.bind(this)
+    );
+    this._workspaceReordered = workspaceManager.connect_after(
+      "workspaces-reordered",
       this.add_indicators.bind(this)
     );
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "settings-schema": "org.gnome.shell.extensions.improved-workspace-indicator",
   "description": "Slightly improved workspace indicator that shows both current and in use workspaces similar to i3/sway",
   "shell-version": ["3.38", "40", "41", "42", "43"],
-  "version": 13,
+  "version": 14,
   "original-authors": ["michaelaquilina@gmail.com"],
   "url": "https://github.com/MichaelAquilina/improved-workspace-indicator"
 }


### PR DESCRIPTION
Reordering a workspace (using https://github.com/smmr0/gnome-reorder-workspaces , for example) should make the workspace indicator update it's value