### PR TITLE
Add Mouse scroll support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,7 +9,7 @@ const workspaceManager = global.workspace_manager;
 
 
 // workspace switch to previous / next
-const scroll_wrap = false;
+let scroll_wrap = false;
 function workspace_switch(d){
   let i = workspaceManager.get_active_workspace_index()
   let n = workspaceManager.get_n_workspaces()
@@ -143,6 +143,15 @@ class WorkspaceLayout {
       "changed::change-on-scroll",
       () => {
         this.add_panel_button();
+      }
+    );
+    //scroll wraparound
+    scroll_wrap = this.settings.get_boolean("wrap-scroll");
+    this._changeOnScrollChangedId = this.settings.connect(
+      "changed::wrap-scroll",
+      () => {
+        scroll_wrap = this.settings.get_boolean("wrap-scroll")
+        // log(`wrap-scoll changed: ${scroll_wrap}`)
       }
     );
 

--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,22 @@ const PanelMenu = imports.ui.panelMenu;
 const Me = ExtensionUtils.getCurrentExtension();
 const workspaceManager = global.workspace_manager;
 
+
+// workspace switch to previous / next
+const scroll_wrap = false;
+function workspace_switch(d){
+  let i = workspaceManager.get_active_workspace_index()
+  let n = workspaceManager.get_n_workspaces()
+
+  let x = (i+d+n)%n
+  if (!scroll_wrap){
+    if(i+d>=n || i+d<0) x = i
+  }
+
+  // print(`=== workspace_switch ${d}: ${i} => ${x}`)
+  workspaceManager.get_workspace_by_index(x).activate(global.get_current_time())
+}
+
 let WorkspaceIndicator = GObject.registerClass(
   class WorkspaceIndicator extends St.Button {
     _init(workspace, active, skip_taskbar_mode, change_on_click) {
@@ -146,6 +162,18 @@ class WorkspaceLayout {
     );
     this.box_layout = new St.BoxLayout();
     this.panel_button.add_actor(this.box_layout);
+
+    // log('\n\n--- panel_button connect scroll-event')
+    this.panel_button.connect('scroll-event', (a, e) => {
+      // print(`--- panel_button: scroll ${a}, ${e}, type: ${e.type()}, direction:, ${e.get_scroll_direction()}`)
+
+      let d = e.get_scroll_direction()
+      if (d == Clutter.ScrollDirection.UP){
+        workspace_switch(-1)
+      }else if (d == Clutter.ScrollDirection.DOWN){
+        workspace_switch(+1)
+      }
+    });
 
     let [position] = this.settings.get_value("panel-position").get_string();
     Main.panel.addToStatusArea(

--- a/extension.js
+++ b/extension.js
@@ -9,8 +9,7 @@ const workspaceManager = global.workspace_manager;
 
 
 // workspace switch to previous / next
-let scroll_wrap = false;
-function workspace_switch(step){
+function workspace_switch(step, scroll_wrap){
   let active_index = workspaceManager.get_active_workspace_index()
   let workspace_count = workspaceManager.get_n_workspaces()
 
@@ -145,11 +144,10 @@ class WorkspaceLayout {
       }
     );
     //scroll wraparound
-    scroll_wrap = this.settings.get_boolean("wrap-scroll");
     this._changeOnScrollChangedId = this.settings.connect(
       "changed::wrap-scroll",
       () => {
-        scroll_wrap = this.settings.get_boolean("wrap-scroll")
+        this.add_panel_button();
       }
     );
 
@@ -179,13 +177,15 @@ class WorkspaceLayout {
 
     let change_on_scroll = this.settings.get_boolean("change-on-scroll");
     if (change_on_scroll) {
+      let scroll_wrap = this.settings.get_boolean("wrap-scroll");
       this.panel_button.connect('scroll-event', (_, event) => {
-        let direction = event.get_scroll_direction()
-        if (direction == Clutter.ScrollDirection.UP) {
-          workspace_switch(-1)
-        }else if (direction == Clutter.ScrollDirection.DOWN){
-          workspace_switch(+1)
+        let switch_step = 0
+        switch(event.get_scroll_direction()){
+          case Clutter.ScrollDirection.UP:   switch_step = -1; break;
+          case Clutter.ScrollDirection.DOWN: switch_step = +1; break;
         }
+
+        if (switch_step) workspace_switch(switch_step, scroll_wrap)
       });
     }
 

--- a/extension.js
+++ b/extension.js
@@ -19,7 +19,6 @@ function workspace_switch(d){
     if(i+d>=n || i+d<0) x = i
   }
 
-  // print(`=== workspace_switch ${d}: ${i} => ${x}`)
   workspaceManager.get_workspace_by_index(x).activate(global.get_current_time())
 }
 
@@ -151,7 +150,6 @@ class WorkspaceLayout {
       "changed::wrap-scroll",
       () => {
         scroll_wrap = this.settings.get_boolean("wrap-scroll")
-        // log(`wrap-scoll changed: ${scroll_wrap}`)
       }
     );
 
@@ -180,11 +178,8 @@ class WorkspaceLayout {
     this.panel_button.add_actor(this.box_layout);
 
     let change_on_scroll = this.settings.get_boolean("change-on-scroll");
-    // log(`\n\n--- panel_button connect scroll-event: ${change_on_scroll}`);
     if (change_on_scroll) {
       this.panel_button.connect('scroll-event', (a, e) => {
-        // print(`--- panel_button: scroll ${a}, ${e}, type: ${e.type()}, direction:, ${e.get_scroll_direction()}`)
-
         let d = e.get_scroll_direction();
         if (d == Clutter.ScrollDirection.UP){
           workspace_switch(-1)

--- a/extension.js
+++ b/extension.js
@@ -10,16 +10,16 @@ const workspaceManager = global.workspace_manager;
 
 // workspace switch to previous / next
 let scroll_wrap = false;
-function workspace_switch(d){
-  let i = workspaceManager.get_active_workspace_index()
-  let n = workspaceManager.get_n_workspaces()
+function workspace_switch(step){
+  let active_index = workspaceManager.get_active_workspace_index()
+  let workspace_count = workspaceManager.get_n_workspaces()
 
-  let x = (i+d+n)%n
-  if (!scroll_wrap){
-    if(i+d>=n || i+d<0) x = i
+  let target_index = (active_index + step + workspace_count) % workspace_count
+  if (!scroll_wrap) {
+    if (active_index + step >= workspace_count || active_index + step < 0) target_index = active_index
   }
 
-  workspaceManager.get_workspace_by_index(x).activate(global.get_current_time())
+  workspaceManager.get_workspace_by_index(target_index).activate(global.get_current_time())
 }
 
 let WorkspaceIndicator = GObject.registerClass(
@@ -179,11 +179,11 @@ class WorkspaceLayout {
 
     let change_on_scroll = this.settings.get_boolean("change-on-scroll");
     if (change_on_scroll) {
-      this.panel_button.connect('scroll-event', (a, e) => {
-        let d = e.get_scroll_direction();
-        if (d == Clutter.ScrollDirection.UP){
+      this.panel_button.connect('scroll-event', (_, event) => {
+        let direction = event.get_scroll_direction()
+        if (direction == Clutter.ScrollDirection.UP) {
           workspace_switch(-1)
-        }else if (d == Clutter.ScrollDirection.DOWN){
+        }else if (direction == Clutter.ScrollDirection.DOWN){
           workspace_switch(+1)
         }
       });

--- a/extension.js
+++ b/extension.js
@@ -138,6 +138,13 @@ class WorkspaceLayout {
         this.add_panel_button();
       }
     );
+    //scroll to change workspace
+    this._changeOnScrollChangedId = this.settings.connect(
+      "changed::change-on-scroll",
+      () => {
+        this.add_panel_button();
+      }
+    );
 
     this.add_panel_button();
   }
@@ -163,17 +170,20 @@ class WorkspaceLayout {
     this.box_layout = new St.BoxLayout();
     this.panel_button.add_actor(this.box_layout);
 
-    // log('\n\n--- panel_button connect scroll-event')
-    this.panel_button.connect('scroll-event', (a, e) => {
-      // print(`--- panel_button: scroll ${a}, ${e}, type: ${e.type()}, direction:, ${e.get_scroll_direction()}`)
+    let change_on_scroll = this.settings.get_boolean("change-on-scroll");
+    // log(`\n\n--- panel_button connect scroll-event: ${change_on_scroll}`);
+    if (change_on_scroll) {
+      this.panel_button.connect('scroll-event', (a, e) => {
+        // print(`--- panel_button: scroll ${a}, ${e}, type: ${e.type()}, direction:, ${e.get_scroll_direction()}`)
 
-      let d = e.get_scroll_direction()
-      if (d == Clutter.ScrollDirection.UP){
-        workspace_switch(-1)
-      }else if (d == Clutter.ScrollDirection.DOWN){
-        workspace_switch(+1)
-      }
-    });
+        let d = e.get_scroll_direction();
+        if (d == Clutter.ScrollDirection.UP){
+          workspace_switch(-1)
+        }else if (d == Clutter.ScrollDirection.DOWN){
+          workspace_switch(+1)
+        }
+      });
+    }
 
     let [position] = this.settings.get_value("panel-position").get_string();
     Main.panel.addToStatusArea(

--- a/prefs.js
+++ b/prefs.js
@@ -135,6 +135,27 @@ function buildPrefsWidget() {
     Gio.SettingsBindFlags.DEFAULT
   );
 
+  //scroll wraparound
+  let wrap_scroll_label = new Gtk.Label({
+    label: "Wraparound workspace when mouse-scroll",
+    halign: Gtk.Align.START,
+  });
+  let wrap_scroll_toggle = new Gtk.Switch({
+    active: this.settings.get_boolean("wrap-scroll"),
+    halign: Gtk.Align.END,
+    visible: true,
+  });
+  
+  prefsWidget.attach(wrap_scroll_label, 0, 5, 2, 1);
+  prefsWidget.attach(wrap_scroll_toggle, 2, 5, 2, 1);
+  
+  this.settings.bind(
+    "wrap-scroll",
+    wrap_scroll_toggle,
+    "active",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
   // only gtk3 apps need to run show_all()
   if (ShellVersion < 40) {
     prefsWidget.show_all();

--- a/prefs.js
+++ b/prefs.js
@@ -114,6 +114,27 @@ function buildPrefsWidget() {
     Gio.SettingsBindFlags.DEFAULT
   );
 
+  //scroll to change workspace
+  let change_on_scroll_label = new Gtk.Label({
+    label: "Change workspace on indicator mouse-scroll",
+    halign: Gtk.Align.START,
+  });
+  let change_on_scroll_toggle = new Gtk.Switch({
+    active: this.settings.get_boolean("change-on-scroll"),
+    halign: Gtk.Align.END,
+    visible: true,
+  });
+  
+  prefsWidget.attach(change_on_scroll_label, 0, 4, 2, 1);
+  prefsWidget.attach(change_on_scroll_toggle, 2, 4, 2, 1);
+  
+  this.settings.bind(
+    "change-on-scroll",
+    change_on_scroll_toggle,
+    "active",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
   // only gtk3 apps need to run show_all()
   if (ShellVersion < 40) {
     prefsWidget.show_all();

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -24,5 +24,12 @@
         Set to true to change to the workspace number on indicator click. Set to false to disable any action on click.
       </description>
     </key>
+    <key name="change-on-scroll" type="b">
+      <default>true</default>
+      <summary>Change Workspaces on indicator mouse-scroll.</summary>
+      <description>
+        Set to true to change to the workspace number by mouse-scroll over indicator.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -31,5 +31,12 @@
         Set to true to change to the workspace number by mouse-scroll over indicator.
       </description>
     </key>
+    <key name="wrap-scroll" type="b">
+      <default>true</default>
+      <summary>workspace wraparound with mouse-scroll</summary>
+      <description>
+        Set to true to loop back at first/last workspace when mouse-scroll.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
It's a great extension, I use it every day.


I have a similar need to this user #9 , so I made a little modification to your code

feat: scroll over indicator to swich workspace.
also provide 2 preference settings
- enable mouse-scroll change workspace
- enable wraparound when mouse-scroll

<br>

If there are any code style or modification comments
Please let me know 

<br>

only tested on `ubuntu 22 lts`, `gnome 42.2`