### PR TITLE
Update metadata for Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Improved Workspace Indicator",
   "settings-schema": "org.gnome.shell.extensions.improved-workspace-indicator",
   "description": "Slightly improved workspace indicator that shows both current and in use workspaces similar to i3/sway",
-  "shell-version": ["3.38", "40", "41", "42", "43"],
+  "shell-version": ["3.38", "40", "41", "42", "43", "44"],
   "version": 17,
   "original-authors": ["michaelaquilina@gmail.com"],
   "url": "https://github.com/MichaelAquilina/improved-workspace-indicator"


### PR DESCRIPTION
The extension works fine under Gnome 44. It seems the metadata change is all that's required.