### PR TITLE
Add panel position order

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -150,6 +150,13 @@ class WorkspaceLayout {
       }
     );
 
+    this._panelPositionOrderChanged = this.settings.connect(
+      "changed::panel-position-order",
+      () => {
+        this.add_panel_button();
+      }
+    );
+
     this._skipTaskbarModeChangedId = this.settings.connect(
       "changed::skip-taskbar-mode",
       () => {
@@ -202,7 +209,9 @@ class WorkspaceLayout {
       0.0,
       _("Improved Workspace Indicator")
     );
-    this.box_layout = new St.BoxLayout();
+    this.box_layout = new St.BoxLayout({
+      style_class: "panel-workspace-container",
+    });
     this.panel_button.add_actor(this.box_layout);
 
     let change_on_scroll = this.settings.get_boolean("change-on-scroll");
@@ -224,10 +233,11 @@ class WorkspaceLayout {
     }
 
     let [position] = this.settings.get_value("panel-position").get_string();
+    let positionOrder = this.settings.get_int("panel-position-order");
     Main.panel.addToStatusArea(
       "improved-workspace-indicator",
       this.panel_button,
-      0,
+      positionOrder,
       position
     );
     this._workspaceSwitchedId = workspaceManager.connect_after(

--- a/prefs.js
+++ b/prefs.js
@@ -49,6 +49,13 @@ function buildPrefsWidget() {
     halign: Gtk.Align.START,
   });
 
+  let panel_position_box = new Gtk.Box({
+    orientation: Gtk.Orientation.HORIZONTAL,
+    spacing: 5,
+    halign: Gtk.Align.END,
+    valign: Gtk.Align.CENTER,
+  });
+
   let panel_position_combo = new Gtk.ComboBoxText();
   panel_position_combo.append("left", "left");
   panel_position_combo.append("right", "right");
@@ -56,8 +63,13 @@ function buildPrefsWidget() {
 
   panel_position_combo.active_id = this.settings.get_string("panel-position");
 
-  prefsWidget.attach(panel_position_label, 0, 1, 2, 1);
-  prefsWidget.attach(panel_position_combo, 2, 1, 2, 1);
+  let panel_position_order_spin_button = new Gtk.SpinButton();
+  panel_position_order_spin_button.set_range(0, 10);
+  panel_position_order_spin_button.set_increments(1, 1);
+
+  panel_position_order_spin_button.set_value(
+    this.settings.get_string("panel-position-order")
+  );
 
   this.settings.bind(
     "panel-position",
@@ -65,6 +77,19 @@ function buildPrefsWidget() {
     "active_id",
     Gio.SettingsBindFlags.DEFAULT
   );
+
+  this.settings.bind(
+    "panel-position-order",
+    panel_position_order_spin_button,
+    "value",
+    Gio.SettingsBindFlags.DEFAULT
+  );
+
+  panel_position_box.append(panel_position_combo);
+  panel_position_box.append(panel_position_order_spin_button);
+
+  prefsWidget.attach(panel_position_label, 0, 1, 2, 1);
+  prefsWidget.attach(panel_position_box, 2, 1, 2, 1);
 
   // Skip Taskbar Mode Selector
 
@@ -209,7 +234,7 @@ function buildPrefsWidget() {
 
   custom_css_help.connect("clicked", () => {
     GLib.spawn_command_line_sync(
-      "xdg-open https://github.com/MichaelAquilina/improved-workspace-indicator/blob/main/docs/how_to_custom_css.md",
+      "xdg-open https://github.com/MichaelAquilina/improved-workspace-indicator/blob/main/docs/how_to_custom_css.md"
     );
   });
 

--- a/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.improved-workspace-indicator.gschema.xml
@@ -10,6 +10,10 @@
       <default>'right'</default>
       <summary>Choose the position of the workspace indicator.</summary>
     </key>
+    <key name="panel-position-order" type="i">
+      <default>0</default>
+      <summary>Choose the order of the workspace indicator.</summary>
+    </key>
     <key name="skip-taskbar-mode" type="b">
       <default>true</default>
       <summary>Ignore Taskbar-Skipped Windows.</summary>


### PR DESCRIPTION
I added a setting to specify the panel position order.

![image](https://github.com/MichaelAquilina/improved-workspace-indicator/assets/32327779/83f19452-48e3-4db5-939f-108dc32cb4ca)

It's very useful when you need to specify the position of the extension between different extensions or system buttons eg:

![image](https://github.com/MichaelAquilina/improved-workspace-indicator/assets/32327779/71b34138-1ada-45e7-bf39-d0c8db1021c1)

I also added a class name to the main container of the extension to add spacing between the workspace indicator using a custom CSS

