### PR TITLE
Migration to GNOME 45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 22
+
+- Support for Gnome 45 and 46
+- Drop support for 44 and below due to complexity of support
+
 ## 17
 
 - Introduction of changelog

--- a/extension.js
+++ b/extension.js
@@ -110,7 +110,7 @@ let WorkspaceIndicator = GObject.registerClass(
 );
 
 export default class WorkspaceLayout  extends Extension{
-  constructor() {};
+  constructor() {}
 
   enable() {
     this.indicators = [];

--- a/extension.js
+++ b/extension.js
@@ -110,6 +110,7 @@ let WorkspaceIndicator = GObject.registerClass(
 );
 
 export default class WorkspaceLayout  extends Extension{
+  constructor() {};
 
   enable() {
     this.indicators = [];

--- a/extension.js
+++ b/extension.js
@@ -53,7 +53,7 @@ let WorkspaceIndicator = GObject.registerClass(
         this._statusLabel.add_style_class_name("workspace-indicator-active");
       }
 
-      this._widget.add_actor(this._statusLabel);
+      this._widget.add_child(this._statusLabel);
 
       this._thumbnailsBox = new St.BoxLayout({
         style_class: "panel-workspace-indicator-box",
@@ -61,8 +61,8 @@ let WorkspaceIndicator = GObject.registerClass(
         reactive: true,
       });
 
-      this._widget.add_actor(this._thumbnailsBox);
-      this.add_actor(this._widget);
+      this._widget.add_child(this._thumbnailsBox);
+      this.add_child(this._widget);
 
       // Connect signals
       this._windowAddedId = this.workspace.connect("window-added", () =>
@@ -110,7 +110,9 @@ let WorkspaceIndicator = GObject.registerClass(
 );
 
 export default class WorkspaceLayout  extends Extension{
-  constructor() {}
+  constructor(metadata) {
+    super(metadata);
+  }
 
   enable() {
     this.indicators = [];
@@ -208,7 +210,7 @@ export default class WorkspaceLayout  extends Extension{
       _("Improved Workspace Indicator")
     );
     this.box_layout = new St.BoxLayout();
-    this.panel_button.add_actor(this.box_layout);
+    this.panel_button.add_child(this.box_layout);
 
     let change_on_scroll = this.settings.get_boolean("change-on-scroll");
     if (change_on_scroll) {
@@ -258,9 +260,8 @@ export default class WorkspaceLayout  extends Extension{
   add_indicators() {
     this.destroy_indicators();
     let active_index = workspaceManager.get_active_workspace_index();
-    let i = 0;
 
-    for (; i < workspaceManager.get_n_workspaces(); i++) {
+    for (let i = 0; i < workspaceManager.get_n_workspaces(); i++) {
       let workspace = workspaceManager.get_workspace_by_index(i);
       if (workspace !== null) {
         let indicator = new WorkspaceIndicator(
@@ -270,7 +271,7 @@ export default class WorkspaceLayout  extends Extension{
           this.settings.get_boolean("change-on-click")
         );
 
-        this.box_layout.add_actor(indicator);
+        this.box_layout.add_child(indicator);
         this.indicators.push(indicator);
       }
     }

--- a/extension.js
+++ b/extension.js
@@ -1,10 +1,15 @@
-const { Clutter, Gio, GObject, GLib, Meta, St } = imports.gi;
+import Clutter from 'gi://Clutter'
+import GObject from 'gi://GObject'
+import Gio from 'gi://Gio'
+import GLib from 'gi://GLib'
+import Meta from 'gi://Meta'
+import St from 'gi://St'
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
 
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js'
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js'
+
 const workspaceManager = global.workspace_manager;
 
 // workspace switch to previous / next
@@ -104,15 +109,14 @@ let WorkspaceIndicator = GObject.registerClass(
   }
 );
 
-class WorkspaceLayout {
-  constructor() {}
+export default class WorkspaceLayout  extends Extension{
 
   enable() {
     this.indicators = [];
     this.panel_button = null;
     this.box_layout = null;
     this.themeContext = St.ThemeContext.get_for_stage(global.stage);
-    this.settings = ExtensionUtils.getSettings();
+    this.settings = this.getSettings();
 
     // Custom CSS file
     this.css_file = null;
@@ -138,7 +142,7 @@ class WorkspaceLayout {
     }
 
     let gschema = Gio.SettingsSchemaSource.new_from_directory(
-      Me.dir.get_child("schemas").get_path(),
+      this.dir.get_child("schemas").get_path(),
       Gio.SettingsSchemaSource.get_default(),
       false
     );

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Improved Workspace Indicator",
   "settings-schema": "org.gnome.shell.extensions.improved-workspace-indicator",
   "description": "Slightly improved workspace indicator that shows both current and in use workspaces similar to i3/sway",
-  "shell-version": ["3.38", "40", "41", "42", "43", "44", "45"],
+  "shell-version": ["45", "46"],
   "version": 21,
   "original-authors": ["michaelaquilina@gmail.com"],
   "url": "https://github.com/MichaelAquilina/improved-workspace-indicator"

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "settings-schema": "org.gnome.shell.extensions.improved-workspace-indicator",
   "description": "Slightly improved workspace indicator that shows both current and in use workspaces similar to i3/sway",
   "shell-version": ["45", "46"],
-  "version": 21,
+  "version": 22,
   "original-authors": ["michaelaquilina@gmail.com"],
   "url": "https://github.com/MichaelAquilina/improved-workspace-indicator"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,298 +1,310 @@
 "use strict";
 
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
-const GLib = imports.gi.GLib;
+import GLib from 'gi://GLib'
+import Gio from 'gi://Gio'
+import Gtk from 'gi://Gtk'
+import Adw from 'gi://Adw';
 
-const Config = imports.misc.config;
+import * as Config from 'resource:///org/gnome/Shell/Extensions/js/misc/config.js';
 const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-function init() {}
+export default class WorkspaceLayoutPref extends ExtensionPreferences {
+  fillPreferencesWindow(window) {
+    window.settings = this.getSettings();
+    // this.settings = ExtensionUtils.getSettings();
+    const page = new Adw.PreferencesPage();
 
-function buildPrefsWidget() {
-  this.settings = ExtensionUtils.getSettings();
-  let prefsWidget;
-
-  // gtk4 apps do not have a margin property
-  if (ShellVersion >= 40) {
-    prefsWidget = new Gtk.Grid({
-      margin_start: 18,
-      margin_end: 18,
-      margin_top: 18,
-      margin_bottom: 18,
-      column_spacing: 12,
-      row_spacing: 12,
+    const group = new Adw.PreferencesGroup({
+      title: _('Group Title'),
     });
-  } else {
-    prefsWidget = new Gtk.Grid({
-      margin: 18,
-      column_spacing: 12,
-      row_spacing: 12,
-    });
-  }
+    let prefsWidget;
 
-  let title = new Gtk.Label({
-    label: "<b>Improved Workspace Indicator Preferences</b>",
-    halign: Gtk.Align.START,
-    use_markup: true,
-  });
-
-  prefsWidget.attach(title, 0, 0, 2, 1);
-
-  // Panel Position Chooser
-
-  let panel_position_label = new Gtk.Label({
-    label: "Panel Position",
-    halign: Gtk.Align.START,
-  });
-
-  let panel_position_combo = new Gtk.ComboBoxText();
-  panel_position_combo.append("left", "left");
-  panel_position_combo.append("right", "right");
-  panel_position_combo.append("center", "center");
-
-  panel_position_combo.active_id = this.settings.get_string("panel-position");
-
-  prefsWidget.attach(panel_position_label, 0, 1, 2, 1);
-  prefsWidget.attach(panel_position_combo, 2, 1, 2, 1);
-
-  this.settings.bind(
-    "panel-position",
-    panel_position_combo,
-    "active_id",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
-  // Skip Taskbar Mode Selector
-
-  let skip_taskbar_mode_label = new Gtk.Label({
-    label:
-      "Ignore Taskbar-Skipped Windows\r" +
-      "<small>These include hidden windows from the desktop-icons-ng extension.</small>",
-    halign: Gtk.Align.START,
-    use_markup: true,
-  });
-
-  let skip_taskbar_mode_toggle = new Gtk.Switch({
-    active: this.settings.get_boolean("skip-taskbar-mode"),
-    valign: Gtk.Align.CENTER,
-    halign: Gtk.Align.END,
-    visible: true,
-  });
-
-  prefsWidget.attach(skip_taskbar_mode_label, 0, 2, 2, 1);
-  prefsWidget.attach(skip_taskbar_mode_toggle, 2, 2, 2, 1);
-
-  this.settings.bind(
-    "skip-taskbar-mode",
-    skip_taskbar_mode_toggle,
-    "active",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
-  // Enable / Disable change on click
-
-  let change_on_click_label = new Gtk.Label({
-    label: "Change workspace on indicator click",
-    halign: Gtk.Align.START,
-  });
-
-  let change_on_click_toggle = new Gtk.Switch({
-    active: this.settings.get_boolean("change-on-click"),
-    halign: Gtk.Align.END,
-    visible: true,
-  });
-
-  prefsWidget.attach(change_on_click_label, 0, 3, 2, 1);
-  prefsWidget.attach(change_on_click_toggle, 2, 3, 2, 1);
-
-  this.settings.bind(
-    "change-on-click",
-    change_on_click_toggle,
-    "active",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
-  // Scroll to change workspace
-
-  let change_on_scroll_label = new Gtk.Label({
-    label: "Change workspace on indicator mouse-scroll",
-    halign: Gtk.Align.START,
-  });
-
-  let change_on_scroll_toggle = new Gtk.Switch({
-    active: this.settings.get_boolean("change-on-scroll"),
-    halign: Gtk.Align.END,
-    visible: true,
-  });
-
-  prefsWidget.attach(change_on_scroll_label, 0, 4, 2, 1);
-  prefsWidget.attach(change_on_scroll_toggle, 2, 4, 2, 1);
-
-  this.settings.bind(
-    "change-on-scroll",
-    change_on_scroll_toggle,
-    "active",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
-  // Scroll wraparound
-
-  let wrap_scroll_label = new Gtk.Label({
-    label: "Wraparound workspace when mouse-scroll",
-    halign: Gtk.Align.START,
-  });
-  let wrap_scroll_toggle = new Gtk.Switch({
-    active: this.settings.get_boolean("wrap-scroll"),
-    halign: Gtk.Align.END,
-    visible: true,
-  });
-
-  prefsWidget.attach(wrap_scroll_label, 0, 5, 2, 1);
-  prefsWidget.attach(wrap_scroll_toggle, 2, 5, 2, 1);
-
-  this.settings.bind(
-    "wrap-scroll",
-    wrap_scroll_toggle,
-    "active",
-    Gio.SettingsBindFlags.DEFAULT
-  );
-
-  // Custom CSS stylesheet
-
-  if (ShellVersion >= 42) {
-    var custom_css_box = new Gtk.Box({
-      orientation: Gtk.Orientation.HORIZONTAL,
-      css_classes: Array("linked"), // Style class in libadwaita
-      halign: Gtk.Align.END,
-      valign: Gtk.Align.CENTER,
-    });
-  } else {
-    var custom_css_box = new Gtk.Box({
-      orientation: Gtk.Orientation.HORIZONTAL,
-      spacing: 5,
-      halign: Gtk.Align.END,
-      valign: Gtk.Align.CENTER,
-    });
-  }
-
-  let custom_css_label = new Gtk.Label({
-    label:
-      "Custom CSS stylesheet\r" +
-      "<small>You need to reload this extension to see the changes.</small>",
-    halign: Gtk.Align.START,
-    use_markup: true,
-  });
-
-  if (ShellVersion < 40) {
-    let custom_css_help_image = new Gtk.Image({
-      icon_name: "dialog-information-symbolic",
-    });
-
-    var custom_css_help = new Gtk.Button({
-      image: custom_css_help_image,
-      tooltip_text: "Click for more information",
-      halign: Gtk.Align.END,
-      valign: Gtk.Align.CENTER,
-    });
-  } else {
-    var custom_css_help = new Gtk.Button({
-      icon_name: "dialog-information-symbolic",
-      tooltip_text: "Click for more information",
-      halign: Gtk.Align.END,
-      valign: Gtk.Align.CENTER,
-    });
-  }
-
-  custom_css_help.connect("clicked", () => {
-    GLib.spawn_command_line_sync(
-      "xdg-open https://github.com/MichaelAquilina/improved-workspace-indicator/blob/main/docs/how_to_custom_css.md",
-    );
-  });
-
-  let custom_css_entry = new Gtk.Entry({
-    tooltip_text: "Remove path from entry box to restore a original style.",
-  });
-
-  let css_entry_buffer = custom_css_entry.get_buffer();
-
-  let custom_css_set_path = this.settings.get_string("custom-css-path");
-  css_entry_buffer.set_text(custom_css_set_path, custom_css_set_path.length);
-
-  function css_filechooser_open() {
-    let dialog = new Gtk.FileChooserNative({
-      title: "Choose a valid CSS stylesheet file",
-      transient_for: null,
-      modal: true,
-      action: Gtk.FileChooserAction.OPEN,
-    });
-
-    let css_filter = new Gtk.FileFilter();
-    css_filter.set_name("CSS stylesheet (*.css)");
-    css_filter.add_mime_type("text/css");
-    dialog.add_filter(css_filter);
-
-    dialog.connect("response", (self, response) => {
-      if (response === Gtk.ResponseType.ACCEPT) {
-        let gfile = dialog.get_file();
-        let file_path = gfile.get_path();
-        css_entry_buffer.set_text(file_path, file_path.length);
-      }
-      dialog.destroy();
-    });
-    dialog.ref(); // File chooser closes itself if nobody is holding its ref
-    dialog.show();
-  }
-
-  if (ShellVersion < 40) {
-    let custom_css_button_image = new Gtk.Image({
-      icon_name: "folder-symbolic",
-    });
-
-    var custom_css_button = new Gtk.Button({
-      image: custom_css_button_image,
-    });
-  } else {
-    var custom_css_button = new Gtk.Button({
-      icon_name: "folder-symbolic",
-    });
-  }
-
-  custom_css_button.connect("clicked", () => {
-    css_filechooser_open();
-  });
-
-  prefsWidget.connect("unrealize", () => {
-    let custom_css_dest = css_entry_buffer.get_text();
-    if (custom_css_dest !== this.settings.get_string("custom-css-path")) {
-      if (
-        GLib.file_test(custom_css_dest, GLib.FileTest.IS_REGULAR) == true ||
-        custom_css_dest === ""
-      ) {
-        this.settings.set_string("custom-css-path", custom_css_dest);
-      }
+    // gtk4 apps do not have a margin property
+    if (ShellVersion >= 40) {
+      prefsWidget = new Gtk.Grid({
+        margin_start: 18,
+        margin_end: 18,
+        margin_top: 18,
+        margin_bottom: 18,
+        column_spacing: 12,
+        row_spacing: 12,
+      });
+    } else {
+      prefsWidget = new Gtk.Grid({
+        margin: 18,
+        column_spacing: 12,
+        row_spacing: 12,
+      });
     }
-  });
 
-  if (ShellVersion < 40) {
-    custom_css_box.pack_end(custom_css_entry, false, false, 0);
-    custom_css_box.pack_end(custom_css_button, false, false, 0);
-  } else {
-    custom_css_box.append(custom_css_entry);
-    custom_css_box.append(custom_css_button);
+    let title = new Gtk.Label({
+      label: "<b>Improved Workspace Indicator Preferences</b>",
+      halign: Gtk.Align.START,
+      use_markup: true,
+    });
+
+    prefsWidget.attach(title, 0, 0, 2, 1);
+
+    // Panel Position Chooser
+
+    let panel_position_label = new Gtk.Label({
+      label: "Panel Position",
+      halign: Gtk.Align.START,
+    });
+
+    let panel_position_combo = new Gtk.ComboBoxText();
+    panel_position_combo.append("left", "left");
+    panel_position_combo.append("right", "right");
+    panel_position_combo.append("center", "center");
+
+    panel_position_combo.active_id = window.settings.get_string("panel-position");
+
+    prefsWidget.attach(panel_position_label, 0, 1, 2, 1);
+    prefsWidget.attach(panel_position_combo, 2, 1, 2, 1);
+
+    window.settings.bind(
+      "panel-position",
+      panel_position_combo,
+      "active_id",
+      Gio.SettingsBindFlags.DEFAULT
+    );
+
+    // Skip Taskbar Mode Selector
+
+    let skip_taskbar_mode_label = new Gtk.Label({
+      label:
+        "Ignore Taskbar-Skipped Windows\r" +
+        "<small>These include hidden windows from the desktop-icons-ng extension.</small>",
+      halign: Gtk.Align.START,
+      use_markup: true,
+    });
+
+    let skip_taskbar_mode_toggle = new Gtk.Switch({
+      active: window.settings.get_boolean("skip-taskbar-mode"),
+      valign: Gtk.Align.CENTER,
+      halign: Gtk.Align.END,
+      visible: true,
+    });
+
+    prefsWidget.attach(skip_taskbar_mode_label, 0, 2, 2, 1);
+    prefsWidget.attach(skip_taskbar_mode_toggle, 2, 2, 2, 1);
+
+    window.settings.bind(
+      "skip-taskbar-mode",
+      skip_taskbar_mode_toggle,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT
+    );
+
+    // Enable / Disable change on click
+
+    let change_on_click_label = new Gtk.Label({
+      label: "Change workspace on indicator click",
+      halign: Gtk.Align.START,
+    });
+
+    let change_on_click_toggle = new Gtk.Switch({
+      active: window.settings.get_boolean("change-on-click"),
+      halign: Gtk.Align.END,
+      visible: true,
+    });
+
+    prefsWidget.attach(change_on_click_label, 0, 3, 2, 1);
+    prefsWidget.attach(change_on_click_toggle, 2, 3, 2, 1);
+
+    window.settings.bind(
+      "change-on-click",
+      change_on_click_toggle,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT
+    );
+
+    // Scroll to change workspace
+
+    let change_on_scroll_label = new Gtk.Label({
+      label: "Change workspace on indicator mouse-scroll",
+      halign: Gtk.Align.START,
+    });
+
+    let change_on_scroll_toggle = new Gtk.Switch({
+      active: window.settings.get_boolean("change-on-scroll"),
+      halign: Gtk.Align.END,
+      visible: true,
+    });
+
+    prefsWidget.attach(change_on_scroll_label, 0, 4, 2, 1);
+    prefsWidget.attach(change_on_scroll_toggle, 2, 4, 2, 1);
+
+    window.settings.bind(
+      "change-on-scroll",
+      change_on_scroll_toggle,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT
+    );
+
+    // Scroll wraparound
+
+    let wrap_scroll_label = new Gtk.Label({
+      label: "Wraparound workspace when mouse-scroll",
+      halign: Gtk.Align.START,
+    });
+    let wrap_scroll_toggle = new Gtk.Switch({
+      active: window.settings.get_boolean("wrap-scroll"),
+      halign: Gtk.Align.END,
+      visible: true,
+    });
+
+    prefsWidget.attach(wrap_scroll_label, 0, 5, 2, 1);
+    prefsWidget.attach(wrap_scroll_toggle, 2, 5, 2, 1);
+
+    window.settings.bind(
+      "wrap-scroll",
+      wrap_scroll_toggle,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT
+    );
+
+    // Custom CSS stylesheet
+
+    if (ShellVersion >= 42) {
+      var custom_css_box = new Gtk.Box({
+        orientation: Gtk.Orientation.HORIZONTAL,
+        css_classes: Array("linked"), // Style class in libadwaita
+        halign: Gtk.Align.END,
+        valign: Gtk.Align.CENTER,
+      });
+    } else {
+      var custom_css_box = new Gtk.Box({
+        orientation: Gtk.Orientation.HORIZONTAL,
+        spacing: 5,
+        halign: Gtk.Align.END,
+        valign: Gtk.Align.CENTER,
+      });
+    }
+
+    let custom_css_label = new Gtk.Label({
+      label:
+        "Custom CSS stylesheet\r" +
+        "<small>You need to reload this extension to see the changes.</small>",
+      halign: Gtk.Align.START,
+      use_markup: true,
+    });
+
+    if (ShellVersion < 40) {
+      let custom_css_help_image = new Gtk.Image({
+        icon_name: "dialog-information-symbolic",
+      });
+
+      var custom_css_help = new Gtk.Button({
+        image: custom_css_help_image,
+        tooltip_text: "Click for more information",
+        halign: Gtk.Align.END,
+        valign: Gtk.Align.CENTER,
+      });
+    } else {
+      var custom_css_help = new Gtk.Button({
+        icon_name: "dialog-information-symbolic",
+        tooltip_text: "Click for more information",
+        halign: Gtk.Align.END,
+        valign: Gtk.Align.CENTER,
+      });
+    }
+
+    custom_css_help.connect("clicked", () => {
+      GLib.spawn_command_line_sync(
+        "xdg-open https://github.com/MichaelAquilina/improved-workspace-indicator/blob/main/docs/how_to_custom_css.md",
+      );
+    });
+
+    let custom_css_entry = new Gtk.Entry({
+      tooltip_text: "Remove path from entry box to restore a original style.",
+    });
+
+    let css_entry_buffer = custom_css_entry.get_buffer();
+
+    let custom_css_set_path = window.settings.get_string("custom-css-path");
+    css_entry_buffer.set_text(custom_css_set_path, custom_css_set_path.length);
+
+    function css_filechooser_open() {
+      let dialog = new Gtk.FileChooserNative({
+        title: "Choose a valid CSS stylesheet file",
+        transient_for: null,
+        modal: true,
+        action: Gtk.FileChooserAction.OPEN,
+      });
+
+      let css_filter = new Gtk.FileFilter();
+      css_filter.set_name("CSS stylesheet (*.css)");
+      css_filter.add_mime_type("text/css");
+      dialog.add_filter(css_filter);
+
+      dialog.connect("response", (self, response) => {
+        if (response === Gtk.ResponseType.ACCEPT) {
+          let gfile = dialog.get_file();
+          let file_path = gfile.get_path();
+          css_entry_buffer.set_text(file_path, file_path.length);
+        }
+        dialog.destroy();
+      });
+      dialog.ref(); // File chooser closes itself if nobody is holding its ref
+      dialog.show();
+    }
+
+    if (ShellVersion < 40) {
+      let custom_css_button_image = new Gtk.Image({
+        icon_name: "folder-symbolic",
+      });
+
+      var custom_css_button = new Gtk.Button({
+        image: custom_css_button_image,
+      });
+    } else {
+      var custom_css_button = new Gtk.Button({
+        icon_name: "folder-symbolic",
+      });
+    }
+
+    custom_css_button.connect("clicked", () => {
+      css_filechooser_open();
+    });
+
+    prefsWidget.connect("unrealize", () => {
+      let custom_css_dest = css_entry_buffer.get_text();
+      if (custom_css_dest !== window.settings.get_string("custom-css-path")) {
+        if (
+          GLib.file_test(custom_css_dest, GLib.FileTest.IS_REGULAR) == true ||
+          custom_css_dest === ""
+        ) {
+          window.settings.set_string("custom-css-path", custom_css_dest);
+        }
+      }
+    });
+
+    if (ShellVersion < 40) {
+      custom_css_box.pack_end(custom_css_entry, false, false, 0);
+      custom_css_box.pack_end(custom_css_button, false, false, 0);
+    } else {
+      custom_css_box.append(custom_css_entry);
+      custom_css_box.append(custom_css_button);
+    }
+
+    prefsWidget.attach(custom_css_label, 0, 6, 2, 1);
+    prefsWidget.attach(custom_css_help, 1, 6, 1, 1);
+    prefsWidget.attach(custom_css_box, 2, 6, 2, 1);
+
+    // only gtk3 apps need to run show_all()
+    if (ShellVersion < 40) {
+      prefsWidget.show_all();
+    }
+
+
+    group.add(prefsWidget);
+    page.add(group);
+
+    window.add(page);
+
   }
-
-  prefsWidget.attach(custom_css_label, 0, 6, 2, 1);
-  prefsWidget.attach(custom_css_help, 1, 6, 1, 1);
-  prefsWidget.attach(custom_css_box, 2, 6, 2, 1);
-
-  // only gtk3 apps need to run show_all()
-  if (ShellVersion < 40) {
-    prefsWidget.show_all();
-  }
-
-  return prefsWidget;
 }
+

--- a/prefs.js
+++ b/prefs.js
@@ -13,7 +13,6 @@ import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/
 export default class WorkspaceLayoutPref extends ExtensionPreferences {
   fillPreferencesWindow(window) {
     window.settings = this.getSettings();
-    // this.settings = ExtensionUtils.getSettings();
     const page = new Adw.PreferencesPage();
 
     const group = new Adw.PreferencesGroup({
@@ -22,22 +21,14 @@ export default class WorkspaceLayoutPref extends ExtensionPreferences {
     let prefsWidget;
 
     // gtk4 apps do not have a margin property
-    if (ShellVersion >= 40) {
-      prefsWidget = new Gtk.Grid({
-        margin_start: 18,
-        margin_end: 18,
-        margin_top: 18,
-        margin_bottom: 18,
-        column_spacing: 12,
-        row_spacing: 12,
-      });
-    } else {
-      prefsWidget = new Gtk.Grid({
-        margin: 18,
-        column_spacing: 12,
-        row_spacing: 12,
-      });
-    }
+    prefsWidget = new Gtk.Grid({
+      margin_start: 18,
+      margin_end: 18,
+      margin_top: 18,
+      margin_bottom: 18,
+      column_spacing: 12,
+      row_spacing: 12,
+    });
 
     let title = new Gtk.Label({
       label: "<b>Improved Workspace Indicator Preferences</b>",
@@ -168,21 +159,12 @@ export default class WorkspaceLayoutPref extends ExtensionPreferences {
 
     // Custom CSS stylesheet
 
-    if (ShellVersion >= 42) {
-      var custom_css_box = new Gtk.Box({
-        orientation: Gtk.Orientation.HORIZONTAL,
-        css_classes: Array("linked"), // Style class in libadwaita
-        halign: Gtk.Align.END,
-        valign: Gtk.Align.CENTER,
-      });
-    } else {
-      var custom_css_box = new Gtk.Box({
-        orientation: Gtk.Orientation.HORIZONTAL,
-        spacing: 5,
-        halign: Gtk.Align.END,
-        valign: Gtk.Align.CENTER,
-      });
-    }
+    var custom_css_box = new Gtk.Box({
+      orientation: Gtk.Orientation.HORIZONTAL,
+      css_classes: Array("linked"), // Style class in libadwaita
+      halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
+    });
 
     let custom_css_label = new Gtk.Label({
       label:
@@ -192,25 +174,12 @@ export default class WorkspaceLayoutPref extends ExtensionPreferences {
       use_markup: true,
     });
 
-    if (ShellVersion < 40) {
-      let custom_css_help_image = new Gtk.Image({
-        icon_name: "dialog-information-symbolic",
-      });
-
-      var custom_css_help = new Gtk.Button({
-        image: custom_css_help_image,
-        tooltip_text: "Click for more information",
-        halign: Gtk.Align.END,
-        valign: Gtk.Align.CENTER,
-      });
-    } else {
-      var custom_css_help = new Gtk.Button({
-        icon_name: "dialog-information-symbolic",
-        tooltip_text: "Click for more information",
-        halign: Gtk.Align.END,
-        valign: Gtk.Align.CENTER,
-      });
-    }
+    var custom_css_help = new Gtk.Button({
+      icon_name: "dialog-information-symbolic",
+      tooltip_text: "Click for more information",
+      halign: Gtk.Align.END,
+      valign: Gtk.Align.CENTER,
+    });
 
     custom_css_help.connect("clicked", () => {
       GLib.spawn_command_line_sync(
@@ -282,29 +251,16 @@ export default class WorkspaceLayoutPref extends ExtensionPreferences {
       }
     });
 
-    if (ShellVersion < 40) {
-      custom_css_box.pack_end(custom_css_entry, false, false, 0);
-      custom_css_box.pack_end(custom_css_button, false, false, 0);
-    } else {
-      custom_css_box.append(custom_css_entry);
-      custom_css_box.append(custom_css_button);
-    }
+    custom_css_box.append(custom_css_entry);
+    custom_css_box.append(custom_css_button);
 
     prefsWidget.attach(custom_css_label, 0, 6, 2, 1);
     prefsWidget.attach(custom_css_help, 1, 6, 1, 1);
     prefsWidget.attach(custom_css_box, 2, 6, 2, 1);
 
-    // only gtk3 apps need to run show_all()
-    if (ShellVersion < 40) {
-      prefsWidget.show_all();
-    }
-
-
     group.add(prefsWidget);
     page.add(group);
 
     window.add(page);
-
   }
 }
-


### PR DESCRIPTION
fixes #34 
This is my first time contributing to an open-source repository so let me know if I overlooked anything and need to change it.

This PR looks at https://gjs.guide/extensions/upgrading/gnome-shell-45.html#extensionutils as guideline to migrate this extension to GNOME 45.

Upon manual testing, everything seems to work correctly. I have not tested compatibility with previous GNOME versions. 